### PR TITLE
when logged in, recipients now renders a table and services now renders as well

### DIFF
--- a/src/components/pages/Programs/ProgramsContainer.js
+++ b/src/components/pages/Programs/ProgramsContainer.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import RenderProgramsPage from './RenderProgramsPage';
-import { TabletHeader } from '../../common/index';
 import TitleComponent from '../../common/Title';
 import ProgramTable from '../../common/ProgramsTable/ProgramTable';
 

--- a/src/components/pages/Recipients/RecipientsContainer.js
+++ b/src/components/pages/Recipients/RecipientsContainer.js
@@ -1,11 +1,18 @@
 import React from 'react';
 import RenderRecipientsPage from './RenderRecipientsPage';
-import { TabletHeader } from '../../common/index';
+import { TableComponent } from '../../common';
+import TitleComponent from '../../common/Title';
 
 function RecipientsContainer() {
   return (
     <div>
-      <RenderRecipientsPage />
+      <div className="sub-header">
+        <TitleComponent TitleText="Recipients" />
+        <RenderRecipientsPage />
+      </div>
+      <div className="tablectn">
+        <TableComponent />
+      </div>
     </div>
   );
 }

--- a/src/components/pages/Recipients/RenderRecipientsPage.js
+++ b/src/components/pages/Recipients/RenderRecipientsPage.js
@@ -1,13 +1,39 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { addEmployeeAction } from '../../../state/actions';
+import { connect } from 'react-redux';
+import { Button } from 'antd';
+import AddEmployeeForm from '../../forms/AddEmployeeForm';
 
-function RenderRecipientsPage() {
+function RenderRecipientsPage({ addEmployeeAction }) {
+  const [visible, setVisible] = useState(false);
+
+  const onCreate = employeeObj => {
+    addEmployeeAction(employeeObj);
+    setVisible(false);
+  };
+
   return (
     <>
-      <div>
-        <h1>Recipients</h1>
+      <div className="add-employee-btn-ctn">
+        <Button
+          type="primary"
+          onClick={() => {
+            setVisible(true);
+          }}
+        >
+          Add Recipient
+        </Button>
+        <AddEmployeeForm
+          visible={visible}
+          onCreate={onCreate}
+          onCancel={() => {
+            setVisible(false);
+          }}
+        />
       </div>
     </>
   );
 }
 
-export default RenderRecipientsPage;
+// export default RenderRecipientsPage;
+export default connect(null, { addEmployeeAction })(RenderRecipientsPage);

--- a/src/components/pages/Services/ServicesContainer.js
+++ b/src/components/pages/Services/ServicesContainer.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import RenderServicesPage from './RenderServicesPage';
-import { TabletHeader } from '../../common/index';
 import TitleComponent from '../../common/Title';
+import ProgramTable from '../../common/ProgramsTable/ProgramTable';
 
 function ServicesContainer() {
   return (
@@ -10,6 +10,7 @@ function ServicesContainer() {
         <TitleComponent TitleText="Services" />
         <RenderServicesPage />
       </div>
+      <ProgramTable />
     </div>
   );
 }


### PR DESCRIPTION
### Description
when logged in as admin (using service worker login credentials) a user can now click on "Recipients" as well as "Services" and tables will render. The tables do render information as well, however the Recipients table renders with the Employees info and the Services table renders with the Programs info. I will set the new tables up to render with the correct information in the future.

**What work was done?**
Added functionality to the Recipients and the Services components to dynamically render tables instead of being blank.

**Why was this work done?**
Work was done because those tabs need to populate from the back end. The tables are filled with dummy data from the database currently, but will work on getting the appropriate info in the tables in the future.

**What feature / user story is it for?**
For Admin user story as well as Program Manager user story - both of them will need access to these tables

**Any relevant links or images / screenshots**
![image](https://user-images.githubusercontent.com/74742085/117725432-256b8d80-b1b3-11eb-8efe-5fd85f4a1ce3.png)

### Type of change
Please delete options that are not relevant.
[x] New feature (non-breaking change which adds functionality)

Change Status
[x] Completed, ready to review and merge
Has This Been Tested
[x] Yes

### Checklist
[x] My code follows the style guidelines of this project
[x] I have performed a self-review of my own code
[] My code has been reviewed by at least one peer
[x] I have commented my code, particularly in hard-to-understand areas
[x] I have made corresponding changes to the documentation
[x] My changes generate no new warnings
[x] There are no merge conflicts
