### PR TITLE
added an AdminDash page that can be accessed after logging in and the…

### DIFF
--- a/src/components/pages/AdminDash/AdminDashContainer.js
+++ b/src/components/pages/AdminDash/AdminDashContainer.js
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { useOktaAuth } from '@okta/okta-react';
+import RenderAdminDash from './RenderAdminDash';
+import { TableComponent } from '../../common';
+import ProgramTable from '../../common/ProgramsTable/ProgramTable';
+import TitleComponent from '../../common/Title';
+
+function AdminDashContainer() {
+  return (
+    <StyledContainer>
+      <center>
+        <TitleComponent TitleText="Admin Dashboard" />
+      </center>
+      <div className="sub-header">
+        <RenderAdminDash />
+      </div>
+      <div>
+        <TableComponent />
+        <ProgramTable />
+      </div>
+    </StyledContainer>
+  );
+}
+
+const StyledContainer = styled.div`
+  //border: solid 1px red;
+`;
+
+export default AdminDashContainer;

--- a/src/components/pages/AdminDash/RenderAdminDash.js
+++ b/src/components/pages/AdminDash/RenderAdminDash.js
@@ -1,0 +1,102 @@
+import React, { useState } from 'react';
+import { connect } from 'react-redux';
+import { Button } from 'antd';
+import { addEmployeeAction } from '../../../state/actions';
+import AddEmployeeForm from '../../forms/AddEmployeeForm';
+import AddProgramForm from '../../forms/AddProgramForm';
+import AddServiceTypeForm from '../../forms/AddServiceTypeForm';
+import AddRecipientForm from '../../forms/AddRecipientForm';
+
+function RenderAdminDash({ addEmployeeAction }) {
+  const [programVisible, setProgramVisible] = useState(false);
+  const [serviceVisible, setServiceVisible] = useState(false);
+  const [employeeVisible, setEmployeeVisible] = useState(false);
+  const [recipientVisible, setRecipientVisible] = useState(false);
+
+  const onCreate = employeeObj => {
+    addEmployeeAction(employeeObj);
+    setEmployeeVisible(false);
+  };
+
+  return (
+    <>
+      <div className="add-employee-btn-ctn">
+        <Button
+          type="primary"
+          onClick={() => {
+            setProgramVisible(true);
+          }}
+        >
+          Add Program
+        </Button>
+
+        <AddProgramForm
+          visible={programVisible}
+          onCreate={onCreate}
+          onCancel={() => {
+            setProgramVisible(false);
+          }}
+        />
+      </div>
+
+      <div className="add-employee-btn-ctn">
+        <Button
+          type="primary"
+          onClick={() => {
+            setServiceVisible(true);
+          }}
+        >
+          Add Service
+        </Button>
+
+        <AddServiceTypeForm
+          visible={serviceVisible}
+          onCreate={onCreate}
+          onCancel={() => {
+            setServiceVisible(false);
+          }}
+        />
+      </div>
+
+      <div className="add-employee-btn-ctn">
+        <Button
+          type="primary"
+          onClick={() => {
+            setEmployeeVisible(true);
+          }}
+        >
+          Add Employee
+        </Button>
+
+        <AddEmployeeForm
+          visible={employeeVisible}
+          onCreate={onCreate}
+          onCancel={() => {
+            setEmployeeVisible(false);
+          }}
+        />
+      </div>
+
+      <div className="add-employee-btn-ctn">
+        <Button
+          type="primary"
+          onClick={() => {
+            setRecipientVisible(true);
+          }}
+        >
+          Add Recipient
+        </Button>
+
+        <AddRecipientForm
+          visible={recipientVisible}
+          onCreate={onCreate}
+          onCancel={() => {
+            setRecipientVisible(false);
+          }}
+        />
+      </div>
+    </>
+  );
+}
+
+export default connect(null, { addEmployeeAction })(RenderAdminDash);

--- a/src/components/pages/AdminDash/index.js
+++ b/src/components/pages/AdminDash/index.js
@@ -1,0 +1,1 @@
+export { default as AdminDash } from './AdminDashContainer';

--- a/src/components/pages/Employees/EmployeesContainer.js
+++ b/src/components/pages/Employees/EmployeesContainer.js
@@ -6,8 +6,10 @@ import TitleComponent from '../../common/Title';
 function EmployeesContainer() {
   return (
     <div>
-      <div className="sub-header">
+      <center>
         <TitleComponent TitleText="Employees" />
+      </center>
+      <div className="sub-header">
         <RenderEmployeesPage />
       </div>
       <div className="tablectn">

--- a/src/components/pages/Programs/ProgramsContainer.js
+++ b/src/components/pages/Programs/ProgramsContainer.js
@@ -6,11 +6,15 @@ import ProgramTable from '../../common/ProgramsTable/ProgramTable';
 function ProgramsContainer() {
   return (
     <div>
-      <div className="sub-header">
+      <center>
         <TitleComponent TitleText="Programs" />
+      </center>
+      <div className="sub-header">
         <RenderProgramsPage />
       </div>
-      <ProgramTable />
+      <div>
+        <ProgramTable />
+      </div>
     </div>
   );
 }

--- a/src/components/pages/Recipients/RecipientsContainer.js
+++ b/src/components/pages/Recipients/RecipientsContainer.js
@@ -6,8 +6,10 @@ import TitleComponent from '../../common/Title';
 function RecipientsContainer() {
   return (
     <div>
-      <div className="sub-header">
+      <center>
         <TitleComponent TitleText="Recipients" />
+      </center>
+      <div className="sub-header">
         <RenderRecipientsPage />
       </div>
       <div className="tablectn">

--- a/src/components/pages/Services/RenderServicesPage.js
+++ b/src/components/pages/Services/RenderServicesPage.js
@@ -46,7 +46,7 @@ function RenderServicesPage({ addServiceAction }) {
         />
       </div>
 
-      <div className="add-services-btn-ctn">
+      <div className="add-type-btn-ctn">
         <Button
           type="primary"
           onClick={() => {

--- a/src/components/pages/Services/ServicesContainer.js
+++ b/src/components/pages/Services/ServicesContainer.js
@@ -6,8 +6,10 @@ import ProgramTable from '../../common/ProgramsTable/ProgramTable';
 function ServicesContainer() {
   return (
     <div>
-      <div className="services-header">
+      <center>
         <TitleComponent TitleText="Services" />
+      </center>
+      <div className="sub-header">
         <RenderServicesPage />
       </div>
       <ProgramTable />

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ import { Provider } from 'react-redux';
 import { store } from './state/index';
 import 'antd/dist/antd.less';
 import './app.scss';
+import { AdminDash } from './components/pages/AdminDash';
 import { MyProfile } from './components/pages/MyProfile';
 import { EmployeesPage } from './components/pages/Employees';
 import { ProgramsPage } from './components/pages/Programs';
@@ -54,6 +55,7 @@ function App() {
           exact
           component={() => <MyProfile LoadingOutlined={LoadingOutlined} />}
         />
+        <SecureRoute path="/adminDash" component={AdminDash} />
         <SecureRoute path="/employees" component={EmployeesPage} />
         <SecureRoute path="/programs" component={ProgramsPage} />
         <SecureRoute path="/recipients" component={RecipientsPage} />

--- a/src/styles/Employees.scss
+++ b/src/styles/Employees.scss
@@ -1,8 +1,10 @@
 .add-employee-btn-ctn {
-  margin: 1rem 5rem 0 0;
+  //margin: 1rem 5rem 0 0;
+  margin-left: 1.5%;
+  margin-right: 1.5%;
   @media (min-width: 992px) {
     // margin-left: 10rem;
-    margin-right: 10%;
+    //margin-right: 10%;
   }
 }
 

--- a/src/styles/Layout.scss
+++ b/src/styles/Layout.scss
@@ -45,6 +45,6 @@
 
 .desktop-title {
   @media (min-width: 992px) {
-    margin-left: 9%;
+    //margin-left: 9%;
   }
 }

--- a/src/styles/Programs.scss
+++ b/src/styles/Programs.scss
@@ -1,15 +1,18 @@
 .sub-header {
   display: flex;
-  justify-content: space-between;
-  margin-top: 1rem;
+  //align-items: center;
+  justify-content: center;
+  //margin-top: 1rem;
   @media (min-width: 992px) {
-    margin-left: 25px;
+    //margin-left: 25px;
   }
 }
 
 .add-program-btn-ctn {
-  margin: 1rem 5rem 0 0;
+  //margin: 1rem 5rem 0 0;
+  margin-left: 1.5%;
+  margin-right: 1.5%;
   @media (min-width: 992px) {
-    margin-right: 10%;
+    //margin-right: 10%;
   }
 }

--- a/src/styles/Services.scss
+++ b/src/styles/Services.scss
@@ -8,17 +8,19 @@
 }
 
 .add-services-btn-ctn {
-  margin-right: 8%;
-  margin-top: 1rem;
+  //margin-right: 8%;
+  //margin-top: 1rem;
   @media (min-width: 992px) {
-    margin-right: 10%;
+    //margin-right: 10%;
   }
 }
 .add-type-btn-ctn {
-  margin-right: -15%;
-  margin-top: 1rem;
+  //margin-right: -15%;
+  //@debug: 1rem;
+  margin-left: 1.5%;
+  margin-right: 1.5%;
   @media (min-width: 992px) {
-    margin-right: -35%;
+    //margin-right: -35%;
   }
 }
 

--- a/src/styles/commonComponents.scss
+++ b/src/styles/commonComponents.scss
@@ -1,8 +1,8 @@
 .title-container {
-  margin-left: 5rem;
+  //margin-left: 5rem;
   @media (min-width: 992px) {
-    // margin-left: 10rem;
-    margin-left: 5rem;
+    //margin-left: 10rem;
+    //margin-left: 5rem;
   }
 }
 


### PR DESCRIPTION
### Description

added an AdminDash page that can be accessed after logging in and then typing in the URL manually (localhost:3000/adminDash for example). This is an example of what a dashboard may look like. Also changed the layout of each existing page slightly so that the look is cleaner and more dynamic. The title and the buttons are now on two separate lines instead of inline with each other. The inline was causing issues with dynamic resizing of pages and when viewing on iPad dimensions.

**What work was done?**
changed the layout of the existing tabs slightly, and created a /adminDash for the team to check out what a dashboard may look like.

**Why was this work done?**
This was done because logging in and being taken to your own profile to edit it was a weird and counterproductive workflow.

**Any relevant links or images / screenshots**
![image](https://user-images.githubusercontent.com/74742085/118198545-20127b00-b41f-11eb-8890-8958f0cc33a1.png)

### Type of change
Please delete options that are not relevant.
[x] New feature (non-breaking change which adds functionality)

Change Status
[x] Completed, ready to review and merge
Has This Been Tested
[x] Yes

### Checklist
[x] My code follows the style guidelines of this project
[x] I have performed a self-review of my own code
[] My code has been reviewed by at least one peer
[] I have commented my code, particularly in hard-to-understand areas
[] I have made corresponding changes to the documentation
[x] My changes generate no new warnings
[x] There are no merge conflicts
