### PR TITLE
Adds full CRUD functionality to Programs page, and refactors services table, with only READ and DELETE from CRUD functional at the moment

### DIFF
--- a/src/components/common/ProgramsTable/ProgramTable.js
+++ b/src/components/common/ProgramsTable/ProgramTable.js
@@ -31,7 +31,7 @@ const ProgramTable = ({
     getAllProgramsAction();
   }, [change]);
 
-  const isEditing = record => record.id === editingKey;
+  const isEditing = record => record.program_id === editingKey;
 
   const edit = record => {
     form.setFieldsValue({
@@ -40,7 +40,7 @@ const ProgramTable = ({
       description: '',
       ...record,
     });
-    setEditingKey(record.id);
+    setEditingKey(record.program_id);
   };
 
   const cancel = () => {
@@ -150,7 +150,7 @@ const ProgramTable = ({
           <span>
             <Space size="middle">
               <a
-                onClick={() => save(record.id)}
+                onClick={() => save(record.program_id)}
                 style={{ color: '#1890FF', marginRight: 8 }}
               >
                 Save
@@ -173,7 +173,7 @@ const ProgramTable = ({
             <Popconfirm
               title="Sure to delete?"
               onConfirm={() => {
-                deleteProgram(record.id);
+                deleteProgram(record.program_id);
               }}
               danger
             >

--- a/src/components/common/ServicesTable/ServiceTable.js
+++ b/src/components/common/ServicesTable/ServiceTable.js
@@ -19,46 +19,40 @@ import {
 
 //action import
 import {
-  getAllServiceTypesAction,
-  getServiceTypeByIdAction,
-  editServiceTypeAction,
-  deleteServiceTypeAction,
+  getAllServicesAction,
+  getServiceByIdAction,
+  addServiceAction,
+  editServiceAction,
+  deleteServiceAction,
   getAllProgramsAction,
 } from '../../../state/actions';
 
 const TableComponent = ({
-  getAllServiceTypesAction,
-  getServiceTypeByIdAction,
-  editServiceTypeAction,
-  deleteServiceTypeAction,
-  serviceTypes,
+  getAllServicesAction,
+  getServiceByIdAction,
+  addServiceAction,
+  editServiceAction,
+  deleteServiceAction,
+  services,
   programs,
   change,
 }) => {
   // tableData is what is consumed by the antd table on render
   const tableData = [];
 
-  // const initialTagValues = {
-  //   selectedTags: employees.programs,
-  // };
-
   const [form] = Form.useForm();
   const [editingKey, setEditingKey] = useState('');
-  // const [selected, setSelected] = useState(initialTagValues);
 
   useEffect(() => {
-    getAllServiceTypesAction();
-    getAllProgramsAction();
+    getAllServicesAction();
   }, [change]);
 
   const isEditing = record => record.key === editingKey;
 
   const edit = record => {
     form.setFieldsValue({
-      firstName: '',
-      lastName: '',
-      role: '',
-      programs: [],
+      name: '',
+      status: '',
       ...record,
     });
     setEditingKey(record.key);
@@ -68,207 +62,113 @@ const TableComponent = ({
     setEditingKey('');
   };
 
-  const save = async serviceTypeId => {
+  const save = async serviceId => {
     try {
-      const serviceTypeObj = await form.validateFields();
-      console.log('key', serviceTypeId);
-      console.log('edited Row', serviceTypeObj);
-      editServiceTypeAction(serviceTypeId, serviceTypeObj);
+      const serviceObj = await form.validateFields();
+      console.log('key', serviceId);
+      console.log('edited Row', serviceObj);
+      editServiceAction(serviceId, serviceObj);
       setEditingKey('');
     } catch (errInfo) {
       console.log('Validate Failed:', errInfo);
     }
   };
 
-  // Delete functionality is on hold for now
   const deleteUser = key => {
-    // deleteEmployeeAction(key);
+    deleteServiceAction(key);
   };
 
-  // const { CheckableTag } = Tag;
-
-  // const { selectedTags } = selected;
-
-  // const handleSelected = (tag, checked) => {
-  //   // const { selectedTags } = selected;
-  //   const nextSelectedTags = checked
-  //     ? [...selectedTags, tag]
-  //     : selectedTags.filter(t => t !== tag);
-  //   setSelected({ selectedTags: nextSelectedTags });
-  // };
-
-  const selectRole = role => {
-    return role === 'administrator'
-      ? 'Administrator'
-      : role === 'program_manager'
-      ? 'Program Manager'
-      : role === 'service_provider'
-      ? 'Service Provider'
-      : role === 'unassigned'
-      ? 'None'
-      : role;
-  };
-
-  const userObjCreator = () => {
-    if (serviceTypes) {
-      serviceTypes.map(serviceType => {
-        const programs = [];
-        // serviceType.programs.map(program => {
-        //   if (program !== null) {
-        //     programs.push(program.name);
-        //   }
-        // });
+  const serviceObjCreator = () => {
+    if (services) {
+      services.map(service => {
+        let recipientName = service.firstname + ' ' + service.lastname;
         return tableData.push({
-          key: serviceType.id,
-          name: serviceType.name,
-          description: serviceType.description,
+          key: service.service_entries_id,
+          service_name: service.service_name,
+          status: service.status,
+          recipient_name: recipientName,
         });
       });
     }
   };
-  userObjCreator();
+  serviceObjCreator();
 
   const columns = [
     {
       title: 'Service Name',
-      dataIndex: 'name',
-      key: 'name',
+      dataIndex: 'service_name',
+      key: 'service_name',
       editable: true,
       render: (_, record) => {
         const editable = isEditing(record);
         return editable ? (
           <Form.Item
-            name="name"
+            name="service_name"
             style={{ margin: 0 }}
             rules={[
               {
                 required: true,
-                message: `Please Input Service Type Name!`,
+                message: `Please Input Service Name!`,
               },
             ]}
           >
-            <Input defaultValue={record.name} />
+            <Input defaultValue={record.service_name} />
           </Form.Item>
         ) : (
-          <>{record.name}</>
+          <>{record.service_name}</>
         );
       },
     },
     {
-      title: 'Type',
-      dataIndex: 'type',
-      key: 'type',
+      title: 'Status',
+      dataIndex: 'status',
+      key: 'status',
       editable: true,
       render: (_, record) => {
         const editable = isEditing(record);
         return editable ? (
           <Form.Item
-            name="type"
+            name="status"
             style={{ margin: 0 }}
             rules={[
               {
                 required: true,
-                message: `Please Input type!`,
+                message: `Please Input Status!`,
               },
             ]}
           >
-            <Input defaultValue={record.type} />
+            <Input defaultValue={record.status} />
           </Form.Item>
         ) : (
-          <>{record.type}</>
+          <>{record.status}</>
         );
       },
     },
     {
-      title: 'Description',
-      dataIndex: 'description',
-      key: 'description',
+      title: 'Recipient Name',
+      dataIndex: 'recipient_name',
+      key: 'recipient_name',
       editable: true,
       render: (_, record) => {
         const editable = isEditing(record);
         return editable ? (
           <Form.Item
-            name="description"
+            name="recipient_name"
             style={{ margin: 0 }}
             rules={[
               {
                 required: true,
-                message: `Please Input Description!`,
+                message: `Please Input Recipient Name!`,
               },
             ]}
           >
-            <Input defaultValue={record.description} />
+            <Input defaultValue={record.recipient_name} />
           </Form.Item>
         ) : (
-          <>{record.description}</>
+          <>{record.recipient_name}</>
         );
       },
     },
-    // {
-    //   title: 'Programs',
-    //   dataIndex: 'programs',
-    //   key: 'programs',
-    //   editable: true,
-    //   render: (_, record) => {
-    //     const editable = isEditing(record);
-    //     return editable ? (
-    //       <Form.Item
-    //         name="programs"
-    //         style={{ margin: 0 }}
-    //         rules={[
-    //           {
-    //             required: true,
-    //             message: 'Please select programs',
-    //           },
-    //         ]}
-    //       >
-    //         <Select size="middle" mode="multiple">
-    //           {programs.map(item => (
-    //             <Select.Option key={item} value={item.id}>
-    //               {item.name}
-    //             </Select.Option>
-    //           ))}
-    //         </Select>
-    //       </Form.Item>
-    //     ) : (
-    //       //   <Form.Item name={record.dataIndex}>
-    //       //     <>
-    //       //       {programs.map(tag => (
-    //       //         <CheckableTag
-    //       //           key={tag}
-    //       //           checked={selectedTags.indexOf(tag) > -1}
-    //       //           onChange={checked => handleSelected(tag, checked)}
-    //       //         >
-    //       //           {tag}
-    //       //         </CheckableTag>
-    //       //       ))}
-    //       //     </>
-    //       //   </Form.Item>
-    //       // )
-    //       <>
-    //         {record.programs.map(program => {
-    //           return (
-    //             <Tag
-    //               color={
-    //                 program === 'Prevention'
-    //                   ? 'blue'
-    //                   : program === 'Sheltering'
-    //                   ? 'purple'
-    //                   : program === 'Aftercare'
-    //                   ? 'gold'
-    //                   : 'magenta'
-    //               }
-    //               size="small"
-    //               key={program}
-    //             >
-    //               {program}
-    //             </Tag>
-    //           );
-    //         })}
-    //       </>
-    //     );
-    //   },
-    // },
     {
       title: 'Actions',
       dataIndex: 'actions',
@@ -318,7 +218,6 @@ const TableComponent = ({
         <Form form={form}>
           <Table
             className="desktop-table"
-            // rowSelection={CheckboxComponent(tableData)}
             columns={columns}
             dataSource={tableData}
             bordered
@@ -331,16 +230,17 @@ const TableComponent = ({
 
 const mapStateToProps = state => {
   return {
-    serviceTypes: state.serviceType.serviceTypes,
+    services: state.service.services,
     programs: state.program.programs,
-    change: state.employee.change,
+    change: state.service.change,
   };
 };
 
 export default connect(mapStateToProps, {
-  getAllServiceTypesAction,
-  getServiceTypeByIdAction,
-  editServiceTypeAction,
-  deleteServiceTypeAction,
+  getAllServicesAction,
+  getServiceByIdAction,
+  addServiceAction,
+  editServiceAction,
+  deleteServiceAction,
   getAllProgramsAction,
 })(TableComponent);

--- a/src/components/pages/Services/RenderServicesPage.js
+++ b/src/components/pages/Services/RenderServicesPage.js
@@ -70,4 +70,14 @@ function RenderServicesPage({ addServiceAction }) {
   );
 }
 
-export default RenderServicesPage;
+const mapStateToProps = state => {
+  console.log(state);
+  return {
+    services: state.service.services,
+  };
+};
+
+export default connect(mapStateToProps, {
+  addServiceAction,
+  addServiceTypeAction,
+})(RenderServicesPage);

--- a/src/state/actions/serviceActions.js
+++ b/src/state/actions/serviceActions.js
@@ -33,7 +33,7 @@ export const getAllServicesAction = () => dispatch => {
   dispatch({ type: GET_ALL_SERVICE_START });
 
   axiosWithAuth()
-    .get(`/api/services`)
+    .get(`/api/service_entry`)
     .then(res => {
       dispatch({ type: GET_ALL_SERVICE_SUCCESS, payload: res.data });
     })
@@ -49,7 +49,7 @@ export const getServiceByIdAction = serviceId => dispatch => {
   dispatch({ type: GET_SERVICE_START });
 
   axiosWithAuth()
-    .get(`/api/service/${serviceId}`)
+    .get(`/api/service_entry/${serviceId}`)
     .then(res => {
       dispatch({ type: GET_SERVICE_SUCCESS, payload: res.data });
     })
@@ -65,7 +65,7 @@ export const addServiceAction = serviceObj => dispatch => {
   dispatch({ type: ADD_SERVICE_START });
 
   axiosWithAuth()
-    .post(`/api/service`, serviceObj)
+    .post(`/api/service_entry`, serviceObj)
     .then(res => {
       dispatch({ type: ADD_SERVICE_SUCCESS, payload: res.data });
     })
@@ -81,7 +81,7 @@ export const editServiceAction = (serviceId, serviceObj) => dispatch => {
   dispatch({ type: EDIT_SERVICE_START });
 
   axiosWithAuth()
-    .put(`/api/service/${serviceId}`, serviceObj)
+    .put(`/api/service_entry/${serviceId}`, serviceObj)
     .then(res => {
       dispatch({ type: EDIT_SERVICE_SUCCESS, payload: res.data });
     })
@@ -97,7 +97,7 @@ export const deleteServiceAction = serviceId => dispatch => {
   dispatch({ type: DELETE_SERVICE_START });
 
   axiosWithAuth()
-    .delete(`/api/service/${serviceId}`)
+    .delete(`/api/service_entry/${serviceId}`)
     .then(res => {
       dispatch({ type: DELETE_SERVICE_SUCCESS, payload: res.data });
     })


### PR DESCRIPTION
### Description
- This PR adds full CRUD functionality to the programs page and will refactor the services table, pulling from the correct part of the API. Reading and deleting currently works, but updating and creating will need more work, and might need more DB work with the service_entry_add form.

**What work was done?**
- CRUD operations on Programs page implemented
- Service table refactored slightly to better reflect the future idea of the table display.

**Why was this work done?**
- Puts us closer to that Release 1 goal.

**What feature / user story is it for?**
- As an Admin I can add/edit/delete programs on the Program list

**Any relevant links or images / screenshots**
![image](https://user-images.githubusercontent.com/70601119/119204112-d5fa4c80-ba51-11eb-908e-f6cf02c6933b.png)
![image](https://user-images.githubusercontent.com/70601119/119204138-eb6f7680-ba51-11eb-93fa-2308356247ad.png)


### Type of change
Please delete options that are not relevant.
[x] New feature (non-breaking change which adds functionality)

Change Status
[x] Completed, ready to review and merge
Has This Been Tested
[x] Yes

### Checklist
[x] My code follows the style guidelines of this project
[x] I have performed a self-review of my own code
[] My code has been reviewed by at least one peer
[x] I have commented my code, particularly in hard-to-understand areas
[x] I have made corresponding changes to the documentation
[] My changes generate no new warnings
[] There are no merge conflicts
