### PR TITLE
added authentication to each dashboard so that user must be logged in with correct credentials to view the corresponding dashboard

### DIFF
--- a/src/components/pages/MyProfile/MyProfileContainer.js
+++ b/src/components/pages/MyProfile/MyProfileContainer.js
@@ -5,7 +5,7 @@ import { TabletHeader } from '../../common/index';
 import { axiosWithAuth } from '../../../utils/axiosWithAuth';
 import './profile.css';
 import { connect } from 'react-redux';
-import { updateUserAction } from '../../../state/actions';
+import { getUserAction, updateUserAction } from '../../../state/actions';
 import TitleComponent from '../../common/Title';
 
 const initialFormValues = {
@@ -50,9 +50,11 @@ function MyProfileContainer({ LoadingOutlined, updateUserAction }) {
   //brings in user data from back-end
   useEffect(() => {
     axiosWithAuth()
-      .get(`api/profile/${userId}`)
+      .get(`/api/profile/${userId}`)
       .then(res => {
         setCurUser(res.data);
+        console.log(res.data);
+        getUserAction(userId);
         localStorage.setItem('role', res.data.role);
       })
       .catch(err => {
@@ -149,6 +151,8 @@ const mapStateToProps = state => {
   };
 };
 
-export default connect(null, { updateUserAction })(MyProfileContainer);
+export default connect(null, { getUserAction, updateUserAction })(
+  MyProfileContainer
+);
 
 // export default MyProfileContainer;

--- a/src/components/pages/ProgramsDash/ProgramsDashContainer.js
+++ b/src/components/pages/ProgramsDash/ProgramsDashContainer.js
@@ -1,13 +1,42 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import styled from 'styled-components';
+import { connect } from 'react-redux';
 import { useOktaAuth } from '@okta/okta-react';
+import { getUserAction } from '../../../state/actions';
 import RenderProgramsDash from './RenderProgramsDash';
 import { TableComponent } from '../../common';
 import ProgramTable from '../../common/ProgramsTable/ProgramTable';
 import TitleComponent from '../../common/Title';
 
-function ProgramsDashContainer() {
-  return (
+function ProgramsDashContainer(props, { LoadingOutlined }) {
+  const { role } = props;
+  const { authState, authService } = useOktaAuth();
+  const [userId, setUserId] = useState(false);
+  // eslint-disable-next-line
+  const [memoAuthService] = useMemo(() => [authService], []);
+
+  useEffect(() => {
+    let isSubscribed = true;
+
+    memoAuthService
+      .getUser()
+      .then(info => {
+        if (isSubscribed) {
+          setUserId(info.sub);
+        }
+      })
+      .catch(err => {
+        isSubscribed = false;
+        return setUserId(null);
+      });
+    return () => (isSubscribed = false);
+  }, [memoAuthService]);
+
+  useEffect(() => {
+    props.getUserAction(userId);
+  }, [userId]);
+
+  return role === 'program_manager' ? (
     <StyledContainer>
       <center>
         <TitleComponent TitleText="Program Manager Dashboard" />
@@ -19,6 +48,10 @@ function ProgramsDashContainer() {
         <ProgramTable />
       </div>
     </StyledContainer>
+  ) : (
+    <center>
+      <h1>You do not have permission to access this page.</h1>
+    </center>
   );
 }
 
@@ -26,4 +59,12 @@ const StyledContainer = styled.div`
   //border: solid 1px red;
 `;
 
-export default ProgramsDashContainer;
+const mapStateToProps = state => {
+  return {
+    role: state.user.user.role,
+  };
+};
+
+export default connect(mapStateToProps, { getUserAction })(
+  ProgramsDashContainer
+);

--- a/src/components/pages/ProgramsDash/RenderProgramsDash.js
+++ b/src/components/pages/ProgramsDash/RenderProgramsDash.js
@@ -8,13 +8,7 @@ import AddRecipientForm from '../../forms/AddRecipientForm';
 function RenderProgramsDash({ addEmployeeAction }) {
   const [programVisible, setProgramVisible] = useState(false);
   const [serviceVisible, setServiceVisible] = useState(false);
-  const [employeeVisible, setEmployeeVisible] = useState(false);
   const [recipientVisible, setRecipientVisible] = useState(false);
-
-  const onCreate = employeeObj => {
-    addEmployeeAction(employeeObj);
-    setEmployeeVisible(false);
-  };
 
   return (
     <>
@@ -30,7 +24,7 @@ function RenderProgramsDash({ addEmployeeAction }) {
 
         <AddProgramForm
           visible={programVisible}
-          onCreate={onCreate}
+          onCreate={null}
           onCancel={() => {
             setProgramVisible(false);
           }}
@@ -49,7 +43,7 @@ function RenderProgramsDash({ addEmployeeAction }) {
 
         <AddServiceTypeForm
           visible={serviceVisible}
-          onCreate={onCreate}
+          onCreate={null}
           onCancel={() => {
             setServiceVisible(false);
           }}
@@ -68,7 +62,7 @@ function RenderProgramsDash({ addEmployeeAction }) {
 
         <AddRecipientForm
           visible={recipientVisible}
-          onCreate={onCreate}
+          onCreate={null}
           onCancel={() => {
             setRecipientVisible(false);
           }}

--- a/src/components/pages/ServicesDash/RenderServicesDash.js
+++ b/src/components/pages/ServicesDash/RenderServicesDash.js
@@ -5,15 +5,8 @@ import AddServiceTypeForm from '../../forms/AddServiceTypeForm';
 import AddRecipientForm from '../../forms/AddRecipientForm';
 
 function RenderServicesDash({ addEmployeeAction }) {
-  const [programVisible, setProgramVisible] = useState(false);
   const [serviceVisible, setServiceVisible] = useState(false);
-  const [employeeVisible, setEmployeeVisible] = useState(false);
   const [recipientVisible, setRecipientVisible] = useState(false);
-
-  const onCreate = employeeObj => {
-    addEmployeeAction(employeeObj);
-    setEmployeeVisible(false);
-  };
 
   return (
     <>
@@ -29,7 +22,7 @@ function RenderServicesDash({ addEmployeeAction }) {
 
         <AddServiceTypeForm
           visible={serviceVisible}
-          onCreate={onCreate}
+          onCreate={null}
           onCancel={() => {
             setServiceVisible(false);
           }}
@@ -48,7 +41,7 @@ function RenderServicesDash({ addEmployeeAction }) {
 
         <AddRecipientForm
           visible={recipientVisible}
-          onCreate={onCreate}
+          onCreate={null}
           onCancel={() => {
             setRecipientVisible(false);
           }}

--- a/src/components/pages/ServicesDash/ServicesDashContainer.js
+++ b/src/components/pages/ServicesDash/ServicesDashContainer.js
@@ -1,13 +1,41 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import styled from 'styled-components';
+import { connect } from 'react-redux';
 import { useOktaAuth } from '@okta/okta-react';
+import { getUserAction } from '../../../state/actions';
 import RenderServicesDash from './RenderServicesDash';
-import { TableComponent } from '../../common';
 import ProgramTable from '../../common/ProgramsTable/ProgramTable';
 import TitleComponent from '../../common/Title';
 
-function ServicesDashContainer() {
-  return (
+function ServicesDashContainer(props, { LoadingOutlined }) {
+  const { role } = props;
+  const { authState, authService } = useOktaAuth();
+  const [userId, setUserId] = useState(false);
+  // eslint-disable-next-line
+  const [memoAuthService] = useMemo(() => [authService], []);
+
+  useEffect(() => {
+    let isSubscribed = true;
+
+    memoAuthService
+      .getUser()
+      .then(info => {
+        if (isSubscribed) {
+          setUserId(info.sub);
+        }
+      })
+      .catch(err => {
+        isSubscribed = false;
+        return setUserId(null);
+      });
+    return () => (isSubscribed = false);
+  }, [memoAuthService]);
+
+  useEffect(() => {
+    props.getUserAction(userId);
+  }, [userId]);
+
+  return role === 'service_provider' ? (
     <StyledContainer>
       <center>
         <TitleComponent TitleText="Service Worker Dashboard" />
@@ -17,13 +45,26 @@ function ServicesDashContainer() {
       </div>
       <div>
         <ProgramTable />
+        <div>{role}</div>
       </div>
     </StyledContainer>
+  ) : (
+    <center>
+      <h1>You do not have permission to access this page.</h1>
+    </center>
   );
 }
+
+const mapStateToProps = state => {
+  return {
+    role: state.user.user.role,
+  };
+};
 
 const StyledContainer = styled.div`
   //border: solid 1px red;
 `;
 
-export default ServicesDashContainer;
+export default connect(mapStateToProps, { getUserAction })(
+  ServicesDashContainer
+);

--- a/src/state/reducers/userReducer.js
+++ b/src/state/reducers/userReducer.js
@@ -19,7 +19,7 @@ export const initialUserState = {
     id: '',
     firstName: '',
     lastName: '',
-    role: '',
+    role: 'this is a role',
     updated_at: '',
   },
   status: 'Resolved',


### PR DESCRIPTION
### Description
This PR adds functionality to the dashboards so that they cannot be accessed by a user who does not have correct permissions. Admins can view adminDash but service workers and program managers cannot for example. This is done through redux. The "role" state changes to whatever the role of the person logging in is, and then runs a check on it to see if they are allowed to see the dashboard or not. I am aiming to get the login to dynamically route to the correct dashboard in the next PR.

**What work was done?**
Used Redux to run a check on user permissions and to grant or deny access to each dashboard.

**Why was this work done?**
It did not make sense to have a user log in and be able to view every dashboard. Does not make sense from a functionality standpoint, but also from a security standpoint.

**Any relevant links or images / screenshots**
![image](https://user-images.githubusercontent.com/74742085/119208829-cee33680-ba71-11eb-9430-99d7679d7e25.png)

### Type of change
Please delete options that are not relevant.
[x] New feature (non-breaking change which adds functionality)

Change Status
[x] Completed, ready to review and merge
Has This Been Tested
[x] Yes

### Checklist
[x] My code follows the style guidelines of this project
[x] I have performed a self-review of my own code
[x] My code has been reviewed by at least one peer
[] I have commented my code, particularly in hard-to-understand areas
[] I have made corresponding changes to the documentation
[x] My changes generate no new warnings
[x] There are no merge conflicts
